### PR TITLE
Add option to only render without deploy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,22 @@ jobs:
         # Make a dummy template directory
         mkdir ./templates
         touch ./templates/manifest.yml
+        touch ./templates/template.yml.erb
         touch ./templates/secrets.ejson
-    - uses: ./
+    - name: Test rendering only
+      uses: ./
+      env:
+        KUBERNETES_AUTH_TOKEN: test
+      with: 
+        dockerRegistry: testRegistry
+        kubernetesServer: testServer
+        kubernetesContext: testContext
+        kubernetesNamespace: testNamespace
+        kubernetesTemplateDir: ./templates
+        kranePath: ./krane.sh
+        renderOnly: true
+    - name: Test render and deploy
+      uses: ./
       env:
         KUBERNETES_AUTH_TOKEN: test
       with: 

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,10 @@ inputs:
     description: 'Additional template variable bindings to use in the krane render step; formatted as a JSON object mapping binding name to value.'
     required: false
     default: '{}'
+  renderOnly:
+    description: 'Only render templates, do not deploy. Default false (i.e. render and deploy) [true/false].'
+    required: false
+    default: 'false'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,11 @@ import * as core from '@actions/core'
 
 import {main} from './main'
 
+function toBoolean(value: string): boolean {
+  const regexp = new RegExp(/^(true|1|on|yes)$/i)
+  return regexp.test(value.trim())
+}
+
 async function run(): Promise<void> {
   try {
     const currentSha: string = core.getInput('currentSha')
@@ -16,6 +21,7 @@ async function run(): Promise<void> {
     const kraneSelector: string = core.getInput('kraneSelector')
     const kranePath: string = core.getInput('kranePath')
     const extraBindings: string = core.getInput('extraBindings')
+    const renderOnly: boolean = toBoolean(core.getInput('renderOnly'))
 
     await main(
       currentSha,
@@ -27,7 +33,8 @@ async function run(): Promise<void> {
       kraneTemplateDir,
       kraneSelector,
       kranePath,
-      extraBindings
+      extraBindings,
+      renderOnly
     )
   } catch (error) {
     core.setFailed(error.message)

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,8 @@ export async function main(
   kraneTemplateDir: string,
   kraneSelector: string,
   kranePath: string,
-  extraBindingsRaw: string
+  extraBindingsRaw: string,
+  renderOnly: boolean
 ): Promise<void> {
   const extraBindings: Record<string, string> = JSON.parse(extraBindingsRaw)
   if (!validate(extraBindings)) {
@@ -32,8 +33,6 @@ export async function main(
     kubernetesServer = `https://${kubernetesClusterDomain}:6443`
   }
 
-  await configureKube(kubernetesServer, kubernetesContext, kubernetesNamespace)
-
   const renderedTemplates = await render(
     kranePath,
     currentSha,
@@ -42,6 +41,13 @@ export async function main(
     kraneTemplateDir,
     extraBindings
   )
+
+  if (renderOnly) {
+    return
+  }
+
+  await configureKube(kubernetesServer, kubernetesContext, kubernetesNamespace)
+
   await deploy(
     kranePath,
     kubernetesContext,

--- a/test/test-main.test.ts
+++ b/test/test-main.test.ts
@@ -35,7 +35,8 @@ describe('main entry point', () => {
       kraneTemplateDir,
       kraneSelector,
       kranePath,
-      extraBindingsRaw
+      extraBindingsRaw,
+      false
     )
 
     const kubernetesServer = `https://${kubernetesClusterDomain}:6443`
@@ -87,7 +88,8 @@ describe('main entry point', () => {
       kraneTemplateDir,
       kraneSelector,
       kranePath,
-      extraBindingsRaw
+      extraBindingsRaw,
+      false
     )
 
     expect(configureKube).toHaveBeenCalledTimes(1)
@@ -119,6 +121,44 @@ describe('main entry point', () => {
     )
   })
 
+  test('Renders and does not configure kube or deploy', async () => {
+    const kubernetesServerRaw: string = ''
+    const extraBindingsRaw: string = '{}'
+
+    const renderedTemplates: string = 'rendered templates'
+    mocked(render).mockImplementation(async () => {
+      return renderedTemplates
+    })
+
+    await main(
+      currentSha,
+      dockerRegistry,
+      kubernetesServerRaw,
+      kubernetesContext,
+      kubernetesClusterDomain,
+      kubernetesNamespace,
+      kraneTemplateDir,
+      kraneSelector,
+      kranePath,
+      extraBindingsRaw,
+      true
+    )
+
+    const extraBindings: Record<string, string> = {}
+    expect(render).toHaveBeenCalledTimes(1)
+    expect(render).toHaveBeenCalledWith(
+      kranePath,
+      currentSha,
+      dockerRegistry,
+      kubernetesClusterDomain,
+      kraneTemplateDir,
+      extraBindings
+    )
+
+    expect(configureKube).not.toHaveBeenCalled()
+    expect(deploy).not.toHaveBeenCalled()
+  })
+
   test('Validates JSON bindings invalid syntax', async () => {
     const kubernetesServerRaw: string = ''
     const extraBindingsRaw: string = '{'
@@ -134,7 +174,8 @@ describe('main entry point', () => {
         kraneTemplateDir,
         kraneSelector,
         kranePath,
-        extraBindingsRaw
+        extraBindingsRaw,
+        false
       )
     ).rejects.toThrow(/^Unexpected end of JSON/)
 
@@ -158,7 +199,8 @@ describe('main entry point', () => {
         kraneTemplateDir,
         kraneSelector,
         kranePath,
-        extraBindingsRaw
+        extraBindingsRaw,
+        false
       )
     ).rejects.toThrow(/^Expected extraBindings to be a JSON object/)
 
@@ -182,7 +224,8 @@ describe('main entry point', () => {
         kraneTemplateDir,
         kraneSelector,
         kranePath,
-        extraBindingsRaw
+        extraBindingsRaw,
+        false
       )
     ).rejects.toThrow(/^Expected extraBindings to be a JSON object/)
 


### PR DESCRIPTION
This will allow us to make the krane config check closer to actual deploy step, and not deal with partials directories directly.