### PR TITLE
Override deploy timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,3 +66,4 @@ jobs:
         kubernetesNamespace: testNamespace
         kubernetesTemplateDir: ./templates
         kranePath: ./krane.sh
+        deployTimeout: 30s

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,10 @@ inputs:
     description: 'Only render templates, do not deploy. Default false (i.e. render and deploy) [true/false].'
     required: false
     default: 'false'
+  deployTimeout:
+    description: ''
+    required: false
+    default: '600s'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ inputs:
     required: false
     default: 'false'
   deployTimeout:
-    description: ''
+    description: 'Global timeout for krane deploy. Override this if a deployment is expected to take more than 10 minutes.'
     required: false
     default: '600s'
 runs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -1395,7 +1395,7 @@ const ajv = new ajv_1.default({ allErrors: true });
 const validate = ajv.compile({
     type: 'object'
 });
-function main(currentSha, dockerRegistry, kubernetesContext, kubernetesClusterDomain, kubernetesNamespace, kraneTemplateDir, kraneSelector, kranePath, extraBindingsRaw, renderOnly) {
+function main(currentSha, dockerRegistry, kubernetesContext, kubernetesClusterDomain, kubernetesNamespace, kraneTemplateDir, kraneSelector, kranePath, extraBindingsRaw, renderOnly, deployTimeout) {
     return __awaiter(this, void 0, void 0, function* () {
         const extraBindings = JSON.parse(extraBindingsRaw);
         if (!validate(extraBindings)) {
@@ -1405,7 +1405,7 @@ function main(currentSha, dockerRegistry, kubernetesContext, kubernetesClusterDo
         if (renderOnly) {
             return;
         }
-        yield krane_1.deploy(kranePath, kubernetesContext, kubernetesNamespace, kraneSelector, kraneTemplateDir, renderedTemplates);
+        yield krane_1.deploy(kranePath, kubernetesContext, kubernetesNamespace, kraneSelector, kraneTemplateDir, renderedTemplates, deployTimeout);
     });
 }
 exports.main = main;
@@ -3795,7 +3795,8 @@ function run() {
             const kranePath = core.getInput('kranePath');
             const extraBindings = core.getInput('extraBindings');
             const renderOnly = toBoolean(core.getInput('renderOnly'));
-            yield main_1.main(currentSha, dockerRegistry, kubernetesContext, kubernetesClusterDomain, kubernetesNamespace, kraneTemplateDir, kraneSelector, kranePath, extraBindings, renderOnly);
+            const deployTimeout = core.getInput('deployTimeout');
+            yield main_1.main(currentSha, dockerRegistry, kubernetesContext, kubernetesClusterDomain, kubernetesNamespace, kraneTemplateDir, kraneSelector, kranePath, extraBindings, renderOnly, deployTimeout);
         }
         catch (error) {
             core.setFailed(error.message);
@@ -4644,13 +4645,14 @@ function findEjsonFiles(kraneTemplateDir) {
     });
 }
 exports.findEjsonFiles = findEjsonFiles;
-function deploy(kranePath, kubernetesContext, kubernetesNamespace, kraneSelector, kraneTemplateDir, renderedTemplates) {
+function deploy(kranePath, kubernetesContext, kubernetesNamespace, kraneSelector, kraneTemplateDir, renderedTemplates, deployTimeout) {
     return __awaiter(this, void 0, void 0, function* () {
         const ejsonPaths = yield findEjsonFiles(kraneTemplateDir);
         const deployCommand = [
             'deploy',
             kubernetesNamespace,
             kubernetesContext,
+            `--global-timeout=${deployTimeout}`,
             `--selector=${kraneSelector}`,
             '--filenames',
             '-'

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ async function run(): Promise<void> {
     const kranePath: string = core.getInput('kranePath')
     const extraBindings: string = core.getInput('extraBindings')
     const renderOnly: boolean = toBoolean(core.getInput('renderOnly'))
+    const deployTimeout: string = core.getInput('deployTimeout')
 
     await main(
       currentSha,
@@ -32,7 +33,8 @@ async function run(): Promise<void> {
       kraneSelector,
       kranePath,
       extraBindings,
-      renderOnly
+      renderOnly,
+      deployTimeout
     )
   } catch (error) {
     core.setFailed(error.message)

--- a/src/krane.ts
+++ b/src/krane.ts
@@ -97,7 +97,8 @@ async function deploy(
   kubernetesNamespace: string,
   kraneSelector: string,
   kraneTemplateDir: string,
-  renderedTemplates: string
+  renderedTemplates: string,
+  deployTimeout: string
 ): Promise<void> {
   const ejsonPaths = await findEjsonFiles(kraneTemplateDir)
 
@@ -105,6 +106,7 @@ async function deploy(
     'deploy',
     kubernetesNamespace,
     kubernetesContext,
+    `--global-timeout=${deployTimeout}`,
     `--selector=${kraneSelector}`,
     '--filenames',
     '-'

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,8 @@ export async function main(
   kraneSelector: string,
   kranePath: string,
   extraBindingsRaw: string,
-  renderOnly: boolean
+  renderOnly: boolean,
+  deployTimeout: string
 ): Promise<void> {
   const extraBindings: Record<string, string> = JSON.parse(extraBindingsRaw)
   if (!validate(extraBindings)) {
@@ -45,6 +46,7 @@ export async function main(
     kubernetesNamespace,
     kraneSelector,
     kraneTemplateDir,
-    renderedTemplates
+    renderedTemplates,
+    deployTimeout
   )
 }

--- a/test/test-krane.test.ts
+++ b/test/test-krane.test.ts
@@ -124,6 +124,7 @@ describe('krane utilities', () => {
       'deploy',
       'ns',
       'context',
+      '--global-timeout=600s',
       '--selector=krane=true',
       '--filenames',
       '-',
@@ -131,7 +132,7 @@ describe('krane utilities', () => {
       '/nonono/third.ejson'
     ]
     const expectedOptions = {input: expect.anything()}
-    await deploy('krane', 'context', 'ns', 'krane=true', '/nonono', '')
+    await deploy('krane', 'context', 'ns', 'krane=true', '/nonono', '', '600s')
     expect(exec.exec).toHaveBeenCalledTimes(1)
     expect(exec.exec).toHaveBeenCalledWith(
       'krane',

--- a/test/test-main.test.ts
+++ b/test/test-main.test.ts
@@ -12,6 +12,7 @@ const kubernetesNamespace: string = 'my-service'
 const kraneTemplateDir: string = 'kubernetes/production'
 const kraneSelector: string = 'managed-by=krane'
 const kranePath: string = 'krane'
+const timeout: string = '600s'
 
 describe('main entry point', () => {
   test('Configures kube, renders and deploys', async () => {
@@ -32,7 +33,8 @@ describe('main entry point', () => {
       kraneSelector,
       kranePath,
       extraBindingsRaw,
-      false
+      false,
+      timeout
     )
 
     const extraBindings: Record<string, string> = {}
@@ -53,7 +55,8 @@ describe('main entry point', () => {
       kubernetesNamespace,
       kraneSelector,
       kraneTemplateDir,
-      renderedTemplates
+      renderedTemplates,
+      timeout
     )
   })
 
@@ -75,7 +78,8 @@ describe('main entry point', () => {
       kraneSelector,
       kranePath,
       extraBindingsRaw,
-      false
+      false,
+      timeout
     )
 
     const extraBindings: Record<string, string> = {}
@@ -96,7 +100,8 @@ describe('main entry point', () => {
       kubernetesNamespace,
       kraneSelector,
       kraneTemplateDir,
-      renderedTemplates
+      renderedTemplates,
+      timeout
     )
   })
 
@@ -118,7 +123,8 @@ describe('main entry point', () => {
       kraneSelector,
       kranePath,
       extraBindingsRaw,
-      true
+      true,
+      timeout
     )
 
     const extraBindings: Record<string, string> = {}
@@ -149,7 +155,8 @@ describe('main entry point', () => {
         kraneSelector,
         kranePath,
         extraBindingsRaw,
-        false
+        false,
+        timeout
       )
     ).rejects.toThrow(/^Unexpected end of JSON/)
 
@@ -171,7 +178,8 @@ describe('main entry point', () => {
         kraneSelector,
         kranePath,
         extraBindingsRaw,
-        false
+        false,
+        timeout
       )
     ).rejects.toThrow(/^Expected extraBindings to be a JSON object/)
 
@@ -193,7 +201,8 @@ describe('main entry point', () => {
         kraneSelector,
         kranePath,
         extraBindingsRaw,
-        false
+        false,
+        timeout
       )
     ).rejects.toThrow(/^Expected extraBindings to be a JSON object/)
 


### PR DESCRIPTION
Add an option to override the krane global timeout, and set the default at `600s`