### PR TITLE
Add better support for custom bindings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+dist/** -diff linguist-generated=true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,8 @@ jobs:
       env:
         KUBERNETES_AUTH_TOKEN: test
         KRANE_BINDING_binding2: value2
-      with: 
+      with:
+        currentSha: ${{ github.sha }}
         dockerRegistry: testRegistry
         kubernetesServer: testServer
         kubernetesContext: testContext
@@ -66,7 +67,8 @@ jobs:
       env:
         KUBERNETES_AUTH_TOKEN: test
         KRANE_BINDING_binding2: value2
-      with: 
+      with:
+        currentSha: ${{ github.sha }}
         dockerRegistry: testRegistry
         kubernetesServer: testServer
         kubernetesContext: testContext

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,6 @@ jobs:
     - name: Test rendering only
       uses: ./
       env:
-        KUBERNETES_AUTH_TOKEN: test
         KRANE_BINDING_binding2: value2
       with:
         currentSha: ${{ github.sha }}
@@ -65,7 +64,6 @@ jobs:
     - name: Test render and deploy
       uses: ./
       env:
-        KUBERNETES_AUTH_TOKEN: test
         KRANE_BINDING_binding2: value2
       with:
         currentSha: ${{ github.sha }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,7 @@ jobs:
       uses: ./
       env:
         KUBERNETES_AUTH_TOKEN: test
+        KRANE_BINDING_binding2: value2
       with: 
         dockerRegistry: testRegistry
         kubernetesServer: testServer
@@ -55,10 +56,15 @@ jobs:
         kubernetesTemplateDir: ./templates
         kranePath: ./krane.sh
         renderOnly: true
+        extraBindings: |
+          {
+            "binding1": "value"
+          }
     - name: Test render and deploy
       uses: ./
       env:
         KUBERNETES_AUTH_TOKEN: test
+        KRANE_BINDING_binding2: value2
       with: 
         dockerRegistry: testRegistry
         kubernetesServer: testServer
@@ -67,3 +73,7 @@ jobs:
         kubernetesTemplateDir: ./templates
         kranePath: ./krane.sh
         deployTimeout: 30s
+        extraBindings: |
+          {
+            "binding1": "value"
+          }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
     - run: |
         # Mock the krane executable
         echo '#!/usr/bin/env bash' > ./krane.sh
+        echo 'echo "$@"' >> ./krane.sh
         chmod u+x ./krane.sh
         # Make a dummy template directory
         mkdir ./templates

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         currentSha: ${{ github.sha }}
         dockerRegistry: testRegistry
-        kubernetesServer: testServer
+        kubernetesClusterDomain: cluster.example.com
         kubernetesContext: testContext
         kubernetesNamespace: testNamespace
         kubernetesTemplateDir: ./templates
@@ -70,7 +70,7 @@ jobs:
       with:
         currentSha: ${{ github.sha }}
         dockerRegistry: testRegistry
-        kubernetesServer: testServer
+        kubernetesClusterDomain: cluster.example.com
         kubernetesContext: testContext
         kubernetesNamespace: testNamespace
         kubernetesTemplateDir: ./templates

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Requires kubectl and krane. Make sure krane is installed on your runner, only ve
 
 ## Environment variables
 - `KUBERNETES_AUTH_TOKEN` - Bearer token for the user entry in kubeconfig
+- `KRANE_BINDING_*` - All variables of this pattern will be injected as bindings to `krane render`.  The binding name will be lower-case, with the `KRANE_BINDING_` prefix removed.
 
 ## Example usage
 
@@ -33,6 +34,9 @@ jobs:
       # Running with renderOnly:true does not require login
       - name: Render templates
         uses: smartlyio/krane-deploy-action@v3
+        env:
+          KRANE_BINDING_canary_revision: "abc123"
+          KRANE_BINDING_user: "deploy-user"
         with:
           renderOnly: true
           currentSha: ${{ github.sha }}
@@ -40,11 +44,6 @@ jobs:
           kubernetesClusterDomain: my-kubernetes-server.example.com
           kubernetesContext: kube-prod
           kubernetesNamespace: my-service-name
-          extraBindings: |
-            {
-              "canary_revision": "abc123",
-              "user": "deploy-user"
-            }
 
   deploy:
     needs: build
@@ -60,17 +59,15 @@ jobs:
           kubernetesNamespace: my-service-name
       - name: Deploy
         uses: smartlyio/krane-deploy-action@v3
+        env:
+          KRANE_BINDING_canary_revision: "abc123"
+          KRANE_BINDING_user: "deploy-user"
         with:
           currentSha: ${{ github.sha }}
           dockerRegistry: hub.docker.com
           kubernetesClusterDomain: my-kubernetes-server.example.com
           kubernetesContext: kube-prod
           kubernetesNamespace: my-service-name
-          extraBindings: |
-            {
-              "canary_revision": "abc123",
-              "user": "deploy-user"
-            }
 ```
 
 Use [docker publish action](https://github.com/smartlyio/Publish-Docker-Github-Action) to build and push docker images in `build` job.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ This action deploys service to kubernetes cluster with [krane](https://github.co
 Requires kubectl and krane. Make sure krane is installed on your runner, only versions >= **1.1.0** are supported.
 
 ## Environment variables
-- `KUBERNETES_AUTH_TOKEN` - Bearer token for the user entry in kubeconfig
 - `KRANE_BINDING_*` - All variables of this pattern will be injected as bindings to `krane render`.  The binding name will be lower-case, with the `KRANE_BINDING_` prefix removed.
 
 ## Example usage

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2
       # Running with renderOnly:true does not require login
       - name: Render templates
-        uses: smartlyio/krane-deploy-action@v3
+        uses: smartlyio/krane-deploy-action@v4
         env:
           KRANE_BINDING_canary_revision: "abc123"
           KRANE_BINDING_user: "deploy-user"
@@ -58,7 +58,7 @@ jobs:
           kubernetesContext: kube-prod
           kubernetesNamespace: my-service-name
       - name: Deploy
-        uses: smartlyio/krane-deploy-action@v3
+        uses: smartlyio/krane-deploy-action@v4
         env:
           KRANE_BINDING_canary_revision: "abc123"
           KRANE_BINDING_user: "deploy-user"

--- a/dist/index.js
+++ b/dist/index.js
@@ -3897,11 +3897,17 @@ function toBoolean(value) {
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            const currentSha = core.getInput('currentSha');
-            const dockerRegistry = core.getInput('dockerRegistry');
-            const kubernetesContext = core.getInput('kubernetesContext');
-            const kubernetesClusterDomain = core.getInput('kubernetesClusterDomain');
-            const kubernetesNamespace = core.getInput('kubernetesNamespace');
+            const currentSha = core.getInput('currentSha', { required: true });
+            const dockerRegistry = core.getInput('dockerRegistry', {
+                required: true
+            });
+            const kubernetesContext = core.getInput('kubernetesContext', {
+                required: true
+            });
+            const kubernetesClusterDomain = core.getInput('kubernetesClusterDomain', { required: true });
+            const kubernetesNamespace = core.getInput('kubernetesNamespace', {
+                required: true
+            });
             const kraneTemplateDir = core.getInput('kubernetesTemplateDir');
             const kraneSelector = core.getInput('kraneSelector');
             const kranePath = core.getInput('kranePath');

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,13 +9,20 @@ function toBoolean(value: string): boolean {
 
 async function run(): Promise<void> {
   try {
-    const currentSha: string = core.getInput('currentSha')
-    const dockerRegistry: string = core.getInput('dockerRegistry')
-    const kubernetesContext: string = core.getInput('kubernetesContext')
+    const currentSha: string = core.getInput('currentSha', {required: true})
+    const dockerRegistry: string = core.getInput('dockerRegistry', {
+      required: true
+    })
+    const kubernetesContext: string = core.getInput('kubernetesContext', {
+      required: true
+    })
     const kubernetesClusterDomain: string = core.getInput(
-      'kubernetesClusterDomain'
+      'kubernetesClusterDomain',
+      {required: true}
     )
-    const kubernetesNamespace: string = core.getInput('kubernetesNamespace')
+    const kubernetesNamespace: string = core.getInput('kubernetesNamespace', {
+      required: true
+    })
     const kraneTemplateDir: string = core.getInput('kubernetesTemplateDir')
     const kraneSelector: string = core.getInput('kraneSelector')
     const kranePath: string = core.getInput('kranePath')

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ async function run(): Promise<void> {
     const kraneTemplateDir: string = core.getInput('kubernetesTemplateDir')
     const kraneSelector: string = core.getInput('kraneSelector')
     const kranePath: string = core.getInput('kranePath')
-    const extraBindings: string = core.getInput('extraBindings')
+    const extraBindingsRaw: string = core.getInput('extraBindings')
     const renderOnly: boolean = toBoolean(core.getInput('renderOnly'))
     const deployTimeout: string = core.getInput('deployTimeout')
 
@@ -32,7 +32,7 @@ async function run(): Promise<void> {
       kraneTemplateDir,
       kraneSelector,
       kranePath,
-      extraBindings,
+      extraBindingsRaw,
       renderOnly,
       deployTimeout
     )

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,51 @@
+import * as core from '@actions/core'
 import {render, deploy} from './krane'
 import Ajv from 'ajv'
 
 const ajv = new Ajv({allErrors: true})
 
 const validate = ajv.compile({
-  type: 'object'
+  type: 'object',
+  patternProperties: {
+    '^.*$': {
+      type: 'string'
+    }
+  }
 })
+
+export const BINDING_PREFIX = 'KRANE_BINDING_'
+
+export async function getExtraBindings(
+  extraBindingsRaw: string
+): Promise<Record<string, string>> {
+  const extraBindings: Record<string, string> = JSON.parse(extraBindingsRaw)
+  if (!validate(extraBindings)) {
+    throw new Error(
+      'Expected extraBindings to be a JSON object mapping binding names to string values'
+    )
+  }
+
+  const bindingInputs: string[] = Object.keys(process.env).filter(name =>
+    name.startsWith(BINDING_PREFIX)
+  )
+
+  for (const bindingInput of bindingInputs) {
+    const bindingName = bindingInput
+      .replace(new RegExp(`^${BINDING_PREFIX}`), '')
+      .toLowerCase()
+    const value = process.env[bindingInput]
+    if (value) {
+      core.info(`Adding krane binding ${bindingName}`)
+      extraBindings[bindingName] = value
+    } else {
+      core.warning(
+        `Failed adding krane binding ${bindingName}: Value doesn't appear to exist!`
+      )
+    }
+  }
+
+  return extraBindings
+}
 
 export async function main(
   currentSha: string,
@@ -20,12 +60,9 @@ export async function main(
   renderOnly: boolean,
   deployTimeout: string
 ): Promise<void> {
-  const extraBindings: Record<string, string> = JSON.parse(extraBindingsRaw)
-  if (!validate(extraBindings)) {
-    throw new Error(
-      'Expected extraBindings to be a JSON object mapping binding names to values'
-    )
-  }
+  const extraBindings: Record<string, string> = await getExtraBindings(
+    extraBindingsRaw
+  )
 
   const renderedTemplates = await render(
     kranePath,

--- a/test/test-main.test.ts
+++ b/test/test-main.test.ts
@@ -138,8 +138,8 @@ describe('main entry point', () => {
     )
 
     const extraBindings: Record<string, string> = {
-      binding1: "value1",
-      binding2: "value2"
+      binding1: 'value1',
+      binding2: 'value2'
     }
     expect(render).toHaveBeenCalledTimes(1)
     expect(render).toHaveBeenCalledWith(
@@ -159,37 +159,37 @@ describe('get extra bindings', () => {
   test('Validates JSON bindings invalid syntax', async () => {
     const extraBindingsRaw: string = '{'
 
-    await expect(
-      getExtraBindings(extraBindingsRaw)
-    ).rejects.toThrow(/^Unexpected end of JSON/)
+    await expect(getExtraBindings(extraBindingsRaw)).rejects.toThrow(
+      /^Unexpected end of JSON/
+    )
   })
 
   test('Validates JSON wrong type string', async () => {
     const extraBindingsRaw: string = '"value"'
 
-    await expect(
-      getExtraBindings(extraBindingsRaw)
-    ).rejects.toThrow(/^Expected extraBindings to be a JSON object/)
+    await expect(getExtraBindings(extraBindingsRaw)).rejects.toThrow(
+      /^Expected extraBindings to be a JSON object/
+    )
   })
 
   test('Validates JSON wrong type array', async () => {
     const extraBindingsRaw: string = '[]'
 
-    await expect(
-      getExtraBindings(extraBindingsRaw)
-    ).rejects.toThrow(/^Expected extraBindings to be a JSON object/)
+    await expect(getExtraBindings(extraBindingsRaw)).rejects.toThrow(
+      /^Expected extraBindings to be a JSON object/
+    )
   })
 
   test('Validates JSON wrong type value', async () => {
     const extraBindingsRaw: string = '{"thing": 1}'
 
-    await expect(
-      getExtraBindings(extraBindingsRaw)
-    ).rejects.toThrow(/^Expected extraBindings to be a JSON object/)
+    await expect(getExtraBindings(extraBindingsRaw)).rejects.toThrow(
+      /^Expected extraBindings to be a JSON object/
+    )
   })
 
   test('Parses JSON extra bindings', async () => {
-    const expected = {"name": "value"}
+    const expected = {name: 'value'}
     const extraBindingsRaw: string = JSON.stringify(expected)
 
     const bindings = await getExtraBindings(extraBindingsRaw)
@@ -198,7 +198,7 @@ describe('get extra bindings', () => {
   })
 
   test('Gets bindings from environment', async () => {
-    const expected = {"name": "value"}
+    const expected = {name: 'value'}
     process.env[`${BINDING_PREFIX}NAME`] = 'value'
 
     const bindings = await getExtraBindings('{}')
@@ -207,7 +207,7 @@ describe('get extra bindings', () => {
   })
 
   test('Merges JSON bindings and environment bindings', async () => {
-    const expected = {"name": "value", "json": "jsonvalue"}
+    const expected = {name: 'value', json: 'jsonvalue'}
     const extraBindingsRaw: string = '{"json": "jsonvalue"}'
     process.env[`${BINDING_PREFIX}NAME`] = 'value'
 
@@ -217,7 +217,7 @@ describe('get extra bindings', () => {
   })
 
   test('Environment bindings take precedence', async () => {
-    const expected = {"name": "value"}
+    const expected = {name: 'value'}
     const extraBindingsRaw: string = '{"name": "jsonvalue"}'
     process.env[`${BINDING_PREFIX}NAME`] = 'value'
 


### PR DESCRIPTION
Custom krane bindings passed through individual environment variables rather than handwritten-json-as-srting-in-yaml

This makes it easier to pass custom/extra bindings to the deployment process.

The `extraBindings` JSON input is still supported for backward compatibility