### PR TITLE
Fix steps to refer to correct outputs

### DIFF
--- a/.github/templates/release.yml.erb
+++ b/.github/templates/release.yml.erb
@@ -20,13 +20,13 @@ jobs:
       @import smartlyio/steps/util/get_next_semantic_version
       @import smartlyio/steps/util/check_branch_behind (is_base_ref: true, remote_update: true)
       - name: Create release
-        if: steps.check_branch_behind.outputs.BRANCH_UP_TO_DATE == 'true' && steps.version_check.continue_release == 'true'
+        if: steps.check_branch_behind.outputs.BRANCH_UP_TO_DATE == 'true' && steps.version_check.outputs.continue_release == 'true'
         run: |
           npm install
           npm version ${{ steps.version_check.outputs.version }}
           git push && git push --tags
       - name: Update action without release
-        if: steps.check_branch_behind.outputs.BRANCH_UP_TO_DATE == 'true' && steps.version_check.continue_release == 'false'
+        if: steps.check_branch_behind.outputs.BRANCH_UP_TO_DATE == 'true' && steps.version_check.outputs.continue_release == 'false'
         run: |
           npm install
           npm run version
@@ -36,7 +36,7 @@ jobs:
             git push
           fi
       - name: Update release branch
-        if: steps.check_branch_behind.outputs.BRANCH_UP_TO_DATE == 'true' && steps.version_check.continue_release == 'true'
+        if: steps.check_branch_behind.outputs.BRANCH_UP_TO_DATE == 'true' && steps.version_check.outputs.continue_release == 'true'
         run: |
           package_version="$(jq -r .version < package.json)"
           release_branch="v${package_version//.*/}"

--- a/.github/workflows/release.generated.yml
+++ b/.github/workflows/release.generated.yml
@@ -167,13 +167,13 @@ jobs:
             echo ::set-output name=BRANCH_UP_TO_DATE::false
           fi
       - name: Create release
-        if: steps.check_branch_behind.outputs.BRANCH_UP_TO_DATE == 'true' && steps.version_check.continue_release == 'true'
+        if: steps.check_branch_behind.outputs.BRANCH_UP_TO_DATE == 'true' && steps.version_check.outputs.continue_release == 'true'
         run: |
           npm install
           npm version ${{ steps.version_check.outputs.version }}
           git push && git push --tags
       - name: Update action without release
-        if: steps.check_branch_behind.outputs.BRANCH_UP_TO_DATE == 'true' && steps.version_check.continue_release == 'false'
+        if: steps.check_branch_behind.outputs.BRANCH_UP_TO_DATE == 'true' && steps.version_check.outputs.continue_release == 'false'
         run: |
           npm install
           npm run version
@@ -183,7 +183,7 @@ jobs:
             git push
           fi
       - name: Update release branch
-        if: steps.check_branch_behind.outputs.BRANCH_UP_TO_DATE == 'true' && steps.version_check.continue_release == 'true'
+        if: steps.check_branch_behind.outputs.BRANCH_UP_TO_DATE == 'true' && steps.version_check.outputs.continue_release == 'true'
         run: |
           package_version="$(jq -r .version < package.json)"
           release_branch="v${package_version//.*/}"


### PR DESCRIPTION
Conditions did not have the right structure:

`steps.version_check.outputs.continue_release == 'true'` was missing the `.outputs` object access