### PR TITLE
Fix duplicate reference to devDependencies patch and missing minor

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,7 +18,7 @@
     },
     {
       "depTypeList": ["devDependencies"],
-      "matchUpdateTypes": ["patch", "major"],
+      "matchUpdateTypes": ["minor", "major"],
       "labels": ["patch", "renovate-deps"]
     },
     {


### PR DESCRIPTION
We had duplicate config for how to label patch level updates to dev dependencies, and nothing for `minor` updates.