### PR TITLE
Update renoveate.json to automerge more kinds of dev dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,15 +11,10 @@
   },
   "packageRules": [
     {
-      "depTypeList": ["devDependencies"],
-      "matchUpdateTypes": ["patch"],
-      "labels": ["no release", "renovate-deps"],
-      "automerge": true
-    },
-    {
-      "depTypeList": ["devDependencies"],
-      "matchUpdateTypes": ["minor", "major"],
-      "labels": ["patch", "renovate-deps"]
+      "groupName": "dependencies",
+      "matchUpdateTypes": ["major"],
+      "depTypeList": ["dependencies"],
+      "labels": ["minor", "renovate-deps"]
     },
     {
       "groupName": "dependencies",
@@ -28,10 +23,34 @@
       "labels": ["patch", "renovate-deps"]
     },
     {
-      "groupName": "dependencies",
+      "depTypeList": ["devDependencies"],
+      "matchPackageNames": ["@vercel/ncc"],
+      "labels": ["patch", "renovate-deps"]
+    },
+    {
+      "depTypeList": ["devDependencies"],
+      "excludePackageNames": ["@vercel/ncc", "typescript"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "labels": ["no release", "renovate-deps"],
+      "automerge": true
+    },
+    {
+      "depTypeList": ["devDependencies"],
+      "matchPackageNames": ["typescript"],
+      "matchUpdateTypes": ["patch"],
+      "labels": ["no release", "renovate-deps"],
+      "automerge": true
+    },
+    {
+      "depTypeList": ["devDependencies"],
+      "matchPackageNames": ["typescript"],
+      "matchUpdateTypes": ["minor"],
+      "labels": ["no release", "renovate-deps"]
+    },
+    {
+      "depTypeList": ["devDependencies"],
       "matchUpdateTypes": ["major"],
-      "depTypeList": ["dependencies"],
-      "labels": ["minor", "renovate-deps"]
+      "labels": ["patch", "renovate-deps"]
     }
   ]
 }


### PR DESCRIPTION
What do you think of this renovate config:

- Production major updates: `minor` release label as before
- Production patch and minor updates: `patch` release as before
- ncc changes (which would change the release build): always `patch` release
- typescript patch: no release, automerge
- dev dependencies patch and minor: no release, automerge
- other dev updates: patch release