### PR TITLE
Update Node.js setup name in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v6
-    - name: Set Node.js 20.x
+    - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
         node-version: 24.x
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v6
-    - name: Set Node.js 20.x
+    - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
         node-version: 24.x


### PR DESCRIPTION
Since Renovate doesn't update the names of the jobs, we shouldn't include the versions in the names.